### PR TITLE
Interface cleanup

### DIFF
--- a/src_ros/draw_sonar_nodelet.cpp
+++ b/src_ros/draw_sonar_nodelet.cpp
@@ -57,7 +57,9 @@ namespace draw_sonar {
     float range( int n ) const override { return _ping->ranges[n]; }
 
     uint8_t intensity( int i ) const override {
-      if( _ping->data_size == 2 ) {
+      if( _ping->data_size == 1 ) {
+        return _ping->intensities[i];
+      } else if( _ping->data_size == 2 ) {
         uint16_t d;
 
         if( _ping->is_bigendian)
@@ -70,9 +72,11 @@ namespace draw_sonar {
           if( d >= (0x1 << (shift+8)) ) return 0xFF;
 
         return (d >> shift);
+      } else {
+        ROS_ERROR_STREAM("SonarImage has unsupported data_size = " << _ping->data_size);
+        return 0;
       }
 
-      return _ping->intensities[i];
     }
 
     imaging_sonar_msgs::SonarImage::ConstPtr _ping;

--- a/src_ros/draw_sonar_nodelet.cpp
+++ b/src_ros/draw_sonar_nodelet.cpp
@@ -50,14 +50,13 @@ namespace draw_sonar {
     SonarImageMsgInterface( const imaging_sonar_msgs::SonarImage::ConstPtr &ping )
       : _ping(ping) {;}
 
-    virtual int nBearings() const         { return _ping->azimuth_angles.size(); }
+    int nBearings() const override { return _ping->azimuth_angles.size(); }
+    float bearing( int n ) const override { return _ping->azimuth_angles[n]; }
 
-    virtual float bearing( int n ) const  { return _ping->azimuth_angles[n];  }
+    int nRanges() const override { return _ping->ranges.size(); }
+    float range( int n ) const override { return _ping->ranges[n]; }
 
-    virtual int nRanges() const           { return _ping->ranges.size(); }
-    virtual float range( int n ) const    { return _ping->ranges[n]; }
-
-    virtual uint8_t intensity( int i ) const {
+    uint8_t intensity( int i ) const override {
       if( _ping->data_size == 2 ) {
         uint16_t d;
 


### PR DESCRIPTION
While double-checking that the draw_sonar node works in azimuth-major fashion
I noticed that it didn't handle the error case of data_size not in {1,2}.

Seemed worth a quick pull request.